### PR TITLE
Query CronCat Factory on instantiate

### DIFF
--- a/cronkitty/src/error.rs
+++ b/cronkitty/src/error.rs
@@ -26,4 +26,9 @@ pub enum ContractError {
 
     #[error("Task hash not found")]
     TaskHashNotFound,
+
+    #[error("Did not find CronCat contract {name} from factory")]
+    NoCronCatContract {
+        name: String
+    },
 }

--- a/cronkitty/src/tests/tests.rs
+++ b/cronkitty/src/tests/tests.rs
@@ -79,14 +79,12 @@ fn cronkitty_plugin_works() {
         .execute_contract(
             suite.ds.controller.clone(),
             suite.proxy.clone(),
-            &ProxyExecuteMsg::InstantiatePlugin::<Empty> {
-                src: vectis_wallet::PluginSource::CodeId(cronkitty_code_id),
-                instantiate_msg: to_binary(&CronKittyInstMsg {
-                    croncat_manager_addr: manager_addr.to_string(),
-                    croncat_tasks_addr: tasks_addr.to_string(),
-                })
-                .unwrap(),
-                plugin_params: PluginParams { grantor: false },
+            &ProxyExecuteMsg::<Empty>::InstantiatePlugin {
+              code_id: 0,
+              instantiate_msg: to_binary(&CronKittyInstMsg {
+                    croncat_factory_addr: factory_addr.to_string(),
+                  }).unwrap(),
+              plugin_params: PluginParams { grantor: false },
                 label: "cronkitty-plugin".into(),
             },
             &[coin(10000, DENOM)],


### PR DESCRIPTION
This makes it so we're gathering the latest versions of the Manager and Tasks contracts. Upon instantiation, it'll use a new helper method `query_croncat_factory_for_contract` to query the Factory contract.

One thing I'll note: since there will be future versions of CronCat contracts, and the CronKitty plugin has the ability to remove/refill tasks, perhaps the helper function can be called again during some custom execute method. Perhaps the owner of the wallet can call `update_kitty_addresses` and this checks if all Tasks have been fulfilled. Once no tasks exist for that user, a clear upgrade to the latest Task and Manager contracts can happen in state.

That may be simpler than the alternative, which is keeping track of which Tasks came from which contract.

---

Lastly, I could not figure out how to get `cargo test` to work properly, specifically with the `ProxyExecuteMsg`. I would continue to get:

```
Caused by:
    Error parsing into type vectis_wallet::msgs::proxy::ProxyExecuteMsg: unknown field `code_id`, expected one of `src`, `instantiate_msg`, `plugin_params`, `label`', cronkitty/src/tests/tests.rs:92:10
```

But then when I remove `code_id` and run it again, it'll immediately tell me I need it. I wonder if this is an odd issue because the `vectis-wallet` dependency uses relative paths? I haven't seen this behavior before. I did have the `vectis` directory up to date with the latest `main` code. Anyway, couldn't figure out how to get that test working. :)

And if this PR is better for reference than merging, I totally get it, just want to help lean in where I can.